### PR TITLE
"use strict" requires that functions be declared at top level

### DIFF
--- a/lib/vtext.js
+++ b/lib/vtext.js
@@ -207,7 +207,7 @@ function getPixels(canvas, context, rawString, fontSize, lineSpacing, styletags)
     zPos = fontSize
 
     var buffer = ""
-    function writeBuffer() {
+    var writeBuffer = function() {
       if(buffer !== "") {
         var delta = context.measureText(buffer).width
 
@@ -216,7 +216,7 @@ function getPixels(canvas, context, rawString, fontSize, lineSpacing, styletags)
       }
     }
 
-    function changeStyle(oldStyle, newStyle) {
+    var changeStyle = function(oldStyle, newStyle) {
 
       function getTextFontSize() {
         return "" + Math.round(zPos) + "px ";


### PR DESCRIPTION
I have been trying to use plotly.js in a production environment and vectorize-text ends up being a dependency.

I get several strict mode violations from the declarations of `writeBuffer()` and `changeStyle(oldStyle, newStyle)`.
```
Error: SyntaxError: in strict mode code, functions may be declared only at top level or immediately within another function
``` 

This is pretty simple to fix by instead declaring these functions as variables.