### PR TITLE
Bump planar-graph-to-polyline in vectorize-text to use binary-search-bounds v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cdt2d": "^1.0.0",
     "clean-pslg": "^1.1.0",
     "ndarray": "^1.0.11",
-    "planar-graph-to-polyline": "^1.0.0",
+    "planar-graph-to-polyline": "^1.0.6",
     "simplify-planar-graph": "^2.0.1",
     "surface-nets": "^1.0.0",
     "triangulate-polyline": "^1.0.0"


### PR DESCRIPTION
`planar-graph-to-polyline@1.06` uses `binary-search-bounds` v2 which has no function constructor.
Follow up of https://github.com/mikolalysenko/planar-graph-to-polyline/pull/2.
@mikolalysenko 

cc: @alexcjohnson
cc: plotly/plotly.js#897

